### PR TITLE
This branch makes NetworkManager deploy connections on a per user basis

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AC_PYTHON_MODULE([dbus], [mandatory])
 AC_PYTHON_MODULE([gobject], [mandatory])
 AC_PYTHON_MODULE([gi], [mandatory])
 AC_PYTHON_MODULE([dbusmock])
+AC_PYTHON_MODULE([mock])
 
 # libexecdir expansion for .desktop file
 # TODO: Make xdgconfigdir parametric

--- a/src/fleetcommanderclient/fcclient.py
+++ b/src/fleetcommanderclient/fcclient.py
@@ -38,45 +38,6 @@ DBUS_OBJECT_PATH = '/org/freedesktop/FleetCommanderClient'
 DBUS_INTERFACE_NAME = 'org.freedesktop.FleetCommanderClient'
 
 
-class FleetCommanderClientDbusClient(object):
-
-    """
-    Fleet commander client dbus client
-    """
-
-    DEFAULT_BUS = dbus.SessionBus
-    CONNECTION_TIMEOUT = 2
-
-    def __init__(self, bus=None):
-        """
-        Class initialization
-        """
-        if bus is None:
-            bus = self.DEFAULT_BUS()
-        self.bus = bus
-
-        t = time.time()
-        while time.time() - t < self.CONNECTION_TIMEOUT:
-            try:
-                self.obj = self.bus.get_object(DBUS_BUS_NAME, DBUS_OBJECT_PATH)
-                self.iface = dbus.Interface(
-                    self.obj, dbus_interface=DBUS_INTERFACE_NAME)
-                return
-            except:
-                pass
-        raise Exception(
-            'Timed out connecting to fleet commander client dbus service')
-
-    def process_sssd_files(self, uid, directory, policy):
-        """
-        Types:
-            uid: Unsigned 32 bit integer (Real local user ID)
-            directory: String (Path where the files has been deployed by SSSD)
-            policy: Unsigned 16 bit integer (as specified in FreeIPA)
-        """
-        return self.iface.ProcessSSSDFiles(uid, directory, policy)
-
-
 class FleetCommanderClientDbusService(dbus.service.Object):
 
     """

--- a/tests/04_configadapter_nm.py
+++ b/tests/04_configadapter_nm.py
@@ -22,63 +22,41 @@
 
 import os
 import sys
-import ConfigParser
-import tempfile
-import shutil
 import unittest
+import uuid
+
+import dbus.service
+import dbus.mainloop.glib
+
+if sys.version_info < (3,):
+    import mock
+else:
+    from unittest import mock
+
+import dbusmock
+from dbusmock.templates.networkmanager import (CSETTINGS_IFACE, MANAGER_IFACE,
+                                               SETTINGS_OBJ, SETTINGS_IFACE)
 
 import gi
 from gi.repository import GLib
 
 sys.path.append(os.path.join(os.environ['TOPSRCDIR'], 'src'))
 
-from fleetcommanderclient.configadapters import networkmanager as canm
 from fleetcommanderclient.configadapters import NetworkManagerConfigAdapter
 
-
-class NetworkManagerDbusHelperMock(object):
+USER_NAME = "myuser"
+def mocked_uname(uid):
     """
-    Network manager dbus helper
+    This is a mock for os.pwd.getpwuid
     """
+    class MockPwd:
+        pw_name = USER_NAME
+    if uid == 1002:
+        return MockPwd()
+    raise Exception("Unknown UID: %d" % uid)
 
-    connections = {}
-
-    def variant_parse(self, serialized_data):
-        return GLib.Variant.parse(None, serialized_data, None, None)
-
-    def get_connection_path_by_uuid(self, uuid):
-        """
-        Returns connection path as an string
-        """
-        if uuid == '0be7d422-1635-11e7-a83f-68f728db19d3':
-            return '/org/freedesktop/NetworkManager/Settings/21'
-        else:
-            raise Exception('NOT FOUND')
-
-    def add_connection(self, connection_data):
-        variant = self.variant_parse(connection_data)
-        pydata = variant.unpack()
-        uuid = pydata['connection']['uuid']
-        if uuid in self.connections:
-            raise Exception('CONNECTION ALREADY EXIST')
-        self.connections[uuid] = pydata
-
-    def update_connection(self, connection_path, connection_data):
-        variant = self.variant_parse(connection_data)
-        pydata = variant.unpack()
-        uuid = pydata['connection']['uuid']
-        if uuid not in self.connections:
-            raise Exception('CONNECTION DOES NOT EXIST')
-        self.connections[uuid] = pydata
-
-
-# Replace DBus helper with mock
-canm.NetworkManagerDbusHelper = NetworkManagerDbusHelperMock
-
-class TestNetworkManagerConfigAdapter(unittest.TestCase):
-
+class TestNetworkManagerConfigAdapter(dbusmock.DBusTestCase):
     TEST_UID = 1002
-
     TEST_DATA = [
         {
             "data": "{'connection': {'id': <'Company VPN'>, 'uuid': <'601d3b48-a44f-40f3-aa7a-35da4a10a099'>, 'type': <'vpn'>, 'autoconnect': <false>, 'secondaries': <@as []>}, 'ipv6': {'method': <'auto'>, 'dns': <@aay []>, 'dns-search': <@as []>, 'address-data': <@aa{sv} []>, 'route-data': <@aa{sv} []>}, 'ipv4': {'method': <'auto'>, 'dns': <@au []>, 'dns-search': <@as []>, 'address-data': <@aa{sv} []>, 'route-data': <@aa{sv} []>}, 'vpn': {'service-type': <'org.freedesktop.NetworkManager.vpnc'>, 'data': <{'NAT Traversal Mode': 'natt', 'ipsec-secret-type': 'ask', 'IPSec secret-flags': '2', 'xauth-password-type': 'ask', 'Vendor': 'cisco', 'Xauth username': 'vpnusername', 'IPSec gateway': 'vpn.mycompany.com', 'Xauth password-flags': '2', 'IPSec ID': 'vpngroupname', 'Perfect Forward Secrecy': 'server', 'IKE DH Group': 'dh2', 'Local Port': '0'}>, 'secrets': <@a{ss} {}>}}",
@@ -94,18 +72,76 @@ class TestNetworkManagerConfigAdapter(unittest.TestCase):
         }
     ]
 
-    def setUp(self):
-        self.ca = NetworkManagerConfigAdapter()
+    @classmethod
+    def setUpClass(klass):
+        klass.start_system_bus()
+        klass.dbus_con = klass.get_dbus(True)
 
+    def setUp(self):
+        self.p_mock, self.obj_nm = self.spawn_server_template(
+                'networkmanager',
+                {'NetworkingEnabled': True})
+        self.settings = dbus.Interface(self.dbus_con.get_object(MANAGER_IFACE,
+                                                                SETTINGS_OBJ),
+                                       SETTINGS_IFACE)
     def tearDown(self):
-        pass
+        self.p_mock.terminate()
+        self.p_mock.wait()
 
     def test_00_bootstrap(self):
-        self.ca.bootstrap(self.TEST_UID)
+        NetworkManagerConfigAdapter().bootstrap(self.TEST_UID)
 
-    def test_01_update(self):
-        self.ca.bootstrap(self.TEST_UID)
-        self.ca.update(self.TEST_UID, self.TEST_DATA)
+    @mock.patch('pwd.getpwuid', side_effect=mocked_uname)
+    def test_01_update(self, side_effect):
+        uuid1 = '601d3b48-a44f-40f3-aa7a-35da4a10a099'
+        uuid2 = '0be7d422-1635-11e7-a83f-68f728db19d3'
+        hashed_uuid1 = str(uuid.uuid5(uuid.UUID(uuid1), USER_NAME))
+        hashed_uuid2 = str(uuid.uuid5(uuid.UUID(uuid2), USER_NAME))
+
+        #We add an existin connection to trigger an Update method
+        self.settings.AddConnection(
+          dbus.Dictionary({
+            'connection': dbus.Dictionary({
+                'id': 'test connection',
+                'uuid': hashed_uuid1,
+                'type': '802-11-wireless'}, signature='sv'),
+            '802-11-wireless': dbus.Dictionary({
+                'ssid': dbus.ByteArray('The_SSID'.encode('UTF-8'))}, signature='sv')
+          })
+        )
+
+        ca = NetworkManagerConfigAdapter()
+        ca.bootstrap(self.TEST_UID)
+        ca.update(self.TEST_UID, self.TEST_DATA)
+
+        path1 = self.settings.GetConnectionByUuid(hashed_uuid1)
+        path2 = self.settings.GetConnectionByUuid(hashed_uuid2)
+
+        conns = self.settings.ListConnections()
+        self.assertEqual(len(conns), 2)
+
+        self.assertIn(path1, conns)
+        self.assertIn(path2, conns)
+
+        conn1 = dbus.Interface(self.dbus_con.get_object(MANAGER_IFACE, path1),
+                               'org.freedesktop.NetworkManager.Settings.Connection')
+        conn2 = dbus.Interface(self.dbus_con.get_object(MANAGER_IFACE, path2),
+                               'org.freedesktop.NetworkManager.Settings.Connection')
+
+        conn1_sett = conn1.GetSettings()
+        conn2_sett = conn2.GetSettings()
+
+        self.assertEqual(conn1_sett['connection']['uuid'], hashed_uuid1)
+        self.assertEqual(conn2_sett['connection']['uuid'], hashed_uuid2)
+
+        self.assertEqual(conn1_sett['connection']['permissions'], ['user:%s:' % USER_NAME,])
+        self.assertEqual(conn2_sett['connection']['permissions'], ['user:%s:' % USER_NAME,])
+
+        self.assertEqual(conn1_sett['user']['data']['org.fleet-commander.connection'], 'true')
+        self.assertEqual(conn1_sett['user']['data']['org.fleet-commander.connection.uuid'], uuid1)
+
+        self.assertEqual(conn2_sett['user']['data']['org.fleet-commander.connection'], 'true')
+        self.assertEqual(conn2_sett['user']['data']['org.fleet-commander.connection.uuid'], uuid2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/_fcclient_tests.py
+++ b/tests/_fcclient_tests.py
@@ -39,8 +39,44 @@ sys.path.append(PYTHONPATH)
 # Fleet commander imports
 from fleetcommanderclient import fcclient
 
+class FleetCommanderClientDbusClient(object):
+    """
+    Fleet commander client dbus client
+    """
 
-class TestDbusClient(fcclient.FleetCommanderClientDbusClient):
+    DEFAULT_BUS = dbus.SessionBus
+    CONNECTION_TIMEOUT = 2
+
+    def __init__(self, bus=None):
+        """
+        Class initialization
+        """
+        if bus is None:
+            bus = self.DEFAULT_BUS()
+        self.bus = bus
+
+        t = time.time()
+        while time.time() - t < self.CONNECTION_TIMEOUT:
+            try:
+                self.obj = self.bus.get_object(fcclient.DBUS_BUS_NAME, fcclient.DBUS_OBJECT_PATH)
+                self.iface = dbus.Interface(
+                    self.obj, dbus_interface=fcclient.DBUS_INTERFACE_NAME)
+                return
+            except:
+                pass
+        raise Exception(
+            'Timed out connecting to fleet commander client dbus service')
+
+    def process_sssd_files(self, uid, directory, policy):
+        """
+        Types:
+            uid: Unsigned 32 bit integer (Real local user ID)
+            directory: String (Path where the files has been deployed by SSSD)
+            policy: Unsigned 16 bit integer (as specified in FreeIPA)
+        """
+        return self.iface.ProcessSSSDFiles(uid, directory, policy)
+
+class TestDbusClient(FleetCommanderClientDbusClient):
     DEFAULT_BUS = dbus.SessionBus
 
     def test_service_alive(self):
@@ -99,7 +135,7 @@ class TestDbusService(unittest.TestCase):
         print('-------- END DBUS SERVICE STDERR --------')
 
     def get_client(self):
-        return fcclient.FleetCommanderClientDbusClient()
+        return TestDbusClient()
 
     def test_00_process_sssd_files(self):
         c = self.get_client()


### PR DESCRIPTION
This patch replaces the uuid of each connection with a hash(uuid + username) and stores the original uuid in the metadata section. It also adds the username to the "permissions" field which limits the visibility of the connection to a specific user.