### PR TITLE
README: Use better command following reconfig

### DIFF
--- a/README
+++ b/README
@@ -33,4 +33,4 @@ read from in /etc/xdg/fleet-commander.conf, this is an example:
 
 After any configuration changes you must restart the daemon:
 
-	# systemctl restart fleet-commander
+	# systemctl reload-or-restart fleet-commander


### PR DESCRIPTION
While the current Fleet Command service lacks high-level reload support in its systemd service, using `reload-or-restart` is more appropriate than `restart` following a reconfiguration. The reason it's more appropriate is because it will cause systemd to prefer a high-level reload if the service implements it, allowing existing scripts and systems management tools to automatically switch to the preferred behavior once possible.

It will continue to perform a full restart as long as a reload isn't possible.